### PR TITLE
Add plugin specific steps support with plugin-ci-jobs.yaml run.sh scripts.

### DIFF
--- a/.buildkite/pull-request-pipeline.yml
+++ b/.buildkite/pull-request-pipeline.yml
@@ -8,7 +8,7 @@
     curl -fsSL --retry-max-time 60 --retry 3 --retry-delay 5 -o /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
     chmod a+x /usr/bin/yq
 
-    mkdir -p .ci && curl -sL --retry 5 --retry-delay 5 https://github.com/mashhurs/.ci/archive/1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards '*Dockerfile*' '*docker*' '*.sh'
+    mkdir -p .ci && curl -sL --retry 5 --retry-delay 5 https://github.com/logstash-plugins/.ci/archive/mashhur-1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards '*Dockerfile*' '*docker*' '*.sh'
 
     echo "--- Generating steps dynamically"
     set +e

--- a/.buildkite/pull-request-pipeline.yml
+++ b/.buildkite/pull-request-pipeline.yml
@@ -8,7 +8,7 @@
     curl -fsSL --retry-max-time 60 --retry 3 --retry-delay 5 -o /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
     chmod a+x /usr/bin/yq
 
-    mkdir -p .ci && curl -sL --retry 5 --retry-delay 5 https://github.com/logstash-plugins/.ci/archive/1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards '*Dockerfile*' '*docker*' '*.sh'
+    mkdir -p .ci && curl -sL --retry 5 --retry-delay 5 https://github.com/mashhurs/.ci/archive/1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards '*Dockerfile*' '*docker*' '*.sh'
 
     echo "--- Generating steps dynamically"
     set +e

--- a/.buildkite/pull-request-pipeline.yml
+++ b/.buildkite/pull-request-pipeline.yml
@@ -1,0 +1,29 @@
+- label: "Pull request pipeline"
+  command: |
+    #!/usr/bin/env bash
+    set -eo pipefail
+    echo "--- Downloading prerequisites"
+    python3 -m pip install ruamel.yaml
+    python3 -m pip install requests
+    curl -fsSL --retry-max-time 60 --retry 3 --retry-delay 5 -o /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+    chmod a+x /usr/bin/yq
+
+    mkdir -p .ci && curl -sL --retry 5 --retry-delay 5 https://github.com/logstash-plugins/.ci/archive/1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards '*Dockerfile*' '*docker*' '*.sh'
+
+    echo "--- Generating steps dynamically"
+    set +e
+    python3 .ci/buildkite/generate-steps.py > pipeline_steps.yml
+    if [[ $$? -ne 0 ]]; then
+      echo "^^^ +++"
+      echo "There was a problem with generating pipeline steps."
+      cat pipeline_steps.yml
+      echo "Exiting now."
+      exit 1
+    else
+      set -eo pipefail
+      cat pipeline_steps.yml | yq .
+    fi
+    
+    set -eo pipefail
+    echo "--- Uploading steps to buildkite"
+    cat pipeline_steps.yml | buildkite-agent pipeline upload

--- a/.buildkite/scripts/pull-request-pipeline/plugin-ci-jobs.yaml
+++ b/.buildkite/scripts/pull-request-pipeline/plugin-ci-jobs.yaml
@@ -1,0 +1,5 @@
+exclude: ELASTIC_STACK_VERSION=7.current
+    
+# additional plugin specific jobs
+jobs:
+  - INTEGRATION=true SECURE_INTEGRATION=true SNAPSHOT=true ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env

--- a/.buildkite/scripts/pull-request-pipeline/run.sh
+++ b/.buildkite/scripts/pull-request-pipeline/run.sh
@@ -1,0 +1,25 @@
+# place any commands which need to run before tests
+
+# check if RabbitMQ port is open
+netstat -tuln | grep 5672
+
+# due ES bootstrap requirements
+# Set the maximum number of memory map areas to 262144
+sudo sysctl -w vm.max_map_count=262144
+
+# Add the PPA repository
+sudo add-apt-repository -y ppa:chris-lea/redis-server
+
+# Update package lists
+sudo apt-get update
+
+# Install redis-server package
+sudo apt-get install -y redis-server
+
+# Stop redis-server service if running
+sudo service redis-server stop
+
+# Start redis-server binding to 0.0.0.0
+sudo service redis-server start --bind 0.0.0.0
+
+.ci/docker-setup.sh && .ci/docker-run.sh


### PR DESCRIPTION
Add plugin specific steps support with plugin-ci-jobs.yaml. Convert travis script configs into plain shell script to run them before CI steps.
