### PR TITLE
Remove 8.previous and 7.current test definitions from CI

### DIFF
--- a/.buildkite/scripts/pull-request-pipeline/plugin-ci-jobs.yaml
+++ b/.buildkite/scripts/pull-request-pipeline/plugin-ci-jobs.yaml
@@ -1,5 +1,3 @@
-exclude: ELASTIC_STACK_VERSION=7.current
     
 # additional plugin specific jobs
 jobs:
-  - INTEGRATION=true SECURE_INTEGRATION=true SNAPSHOT=true ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env

--- a/.buildkite/scripts/pull-request-pipeline/plugin-ci-jobs.yaml
+++ b/.buildkite/scripts/pull-request-pipeline/plugin-ci-jobs.yaml
@@ -1,3 +1,4 @@
     
 # additional plugin specific jobs
 jobs:
+  - INTEGRATION=true SECURE_INTEGRATION=true SNAPSHOT=true ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env


### PR DESCRIPTION
The 8.previous and 7.current stack version aliases are being retired. Remove the corresponding CI entries.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
